### PR TITLE
Create a release workflow to automize publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create_release:
+    needs: build_release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Grab and store version
+        run: |
+          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
+          echo "VERSION=$tag_name" >> $GITHUB_ENV
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+          # specify the build version, overrides whatever is in the build.gradle file
+          arguments: build -PoverrideVersion=${{ env.VERSION }}
+
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          name: Neko Detector ${{ env.VERSION }}
+          draft: true
+          prerelease: false
+          files: |
+            jarscaner-${{ env.VERSION }}.jar

--- a/build.gradle
+++ b/build.gradle
@@ -27,4 +27,14 @@ tasks.shadowJar {
 }
 tasks.build {
     dependsOn(shadowJar)
+    if (project.hasProperty("overrideVersion")) {
+        project.setVersion(overrideVersion)
+        println "Overrided project version to: " + version
+    }
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'me.cortex.jarscanner.Main'
+    }
 }


### PR DESCRIPTION
This pr is dependent upon the gradle fix in #13 to ensure that people are actually able to use the project. (Also if #15 clears the filename in the workflow will need to be updated.)

Any time a tag gets pushed to the repo, a new release will occur, and subsequently a new build will be triggered as well.