### PR TITLE
Minor build script & GitHub Actions improvements 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+          cache-disabled: true
           # specify the build version, overrides whatever is in the build.gradle file
           arguments: build -PoverrideVersion=${{ env.VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,5 +45,4 @@ jobs:
           name: Neko Detector ${{ env.VERSION }}
           draft: true
           prerelease: false
-          files: |
-            jarscanner-${{ env.VERSION }}.jar
+          files: build/libs/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id("com.github.johnrengelman.shadow") version "8.1.1"    
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 group 'me.cortex'
 version '1.0-SNAPSHOT'
@@ -20,13 +20,13 @@ test {
     useJUnitPlatform()
 }
 
-
 tasks.shadowJar {
     archiveClassifier.set("")
     manifest {
         attributes "Main-Class": "me.cortex.jarscanner.Main"
     }
 }
+
 tasks.build {
     dependsOn(shadowJar)
     if (project.hasProperty("overrideVersion")) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 group 'me.cortex'
 version '1.0-SNAPSHOT'
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,13 @@ repositories {
     mavenCentral()
 }
 
+// Reproducible builds
+// https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
 dependencies {
     implementation 'org.ow2.asm:asm:9.5'
     implementation 'org.ow2.asm:asm-tree:9.5'


### PR DESCRIPTION
- Uses Gradle toolchains to find a Java 8 JDK when building
- Improves build reproducibility by configuring Gradle to produce reproducible archives & not using cached files when building release artifacts
- Changes the release action to upload all files in the build/libs folder, removing the need for a hardcoded name
- Minor formatting changes