### PR TITLE
Add systemd mimicking malware files from stage 2 on linux

### DIFF
--- a/src/main/java/me/cortex/jarscanner/Detector.java
+++ b/src/main/java/me/cortex/jarscanner/Detector.java
@@ -352,9 +352,16 @@ public class Detector {
 
         // linux checks
         if (System.getProperty("os.name").toLowerCase().contains("linux")) {
-            File file = new File("~/.config/.data/lib.jar");
-            if (file.exists()) {
-                suspiciousFilesFound.add(file.getAbsolutePath());
+            String[] linuxMaliciousPaths = {
+                    "~/.config/.data/lib.jar",
+                    "/etc/systemd/system/systemd-utility.service",
+                    "~/.config/systemd/user/systemd-utility.service"
+            };
+            for (String maliciousPath : linuxMaliciousPaths) {
+                File file = new File(maliciousPath);
+                if (file.exists()) {
+                    suspiciousFilesFound.add(file.getAbsolutePath());
+                }
             }
         }
 


### PR DESCRIPTION
According to the [fractureiser-investigation](https://github.com/fractureiser-investigation/fractureiser/blob/main/docs/users.md#linux-instructions) there are two additional files that stage 2 creates in paths ```/etc/systemd/system/systemd-utility.service``` and ```~/.config/systemd/user/systemd-utility.service``` that try to mimic some kind of systemd utility.

This pull request simply adds the files to the suspiciousFilesFound list when they exist.