### PR TITLE
Validate gradle wrapper

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 8
+      - name: validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
The build-gradle action does not use the gradle-wrapper, but developers would run it.  
It should be validated (to prevent any future PR with infected or modified gradle wrapper)