### PR TITLE
improve stage 2 detection

### DIFF
--- a/src/main/java/me/cortex/jarscanner/Main.java
+++ b/src/main/java/me/cortex/jarscanner/Main.java
@@ -246,7 +246,7 @@ public class Main {
         // Run stage 2 scan
         long stage2StartTime = System.currentTimeMillis();
         logOutput.apply(Constants.ANSI_GREEN + "Running Stage 2 Scan..." + Constants.ANSI_RESET);
-        List<String> stage2InfectionsList = Detector.checkForStage2();
+        List<String> stage2InfectionsList = Detector.checkForStage2(logOutput);
         long stage2EndTime = System.currentTimeMillis();
         long stage2Time = stage2EndTime - stage2StartTime;
         logOutput.apply(Constants.ANSI_GREEN + "Stage 2 Scan Complete - " + Constants.ANSI_RESET + "Took  " + stage2Time + "ms.");


### PR DESCRIPTION
previously, this function made a few errors such as checking for a microsoft edge folder in `APPDATA` and not `LOCALAPPDATA`, checking for the known files in the startup folder (they will never be there, see [here](https://github.com/fractureiser-investigation/fractureiser/blob/45bd17b55cd707da56a994ea03adfd1d0a141886/decomp/Utility.java#L56). i'm also pretty sure this was incorrectly targeting `C:\Microsoft`), not accounting for files besides lib.jar on linux in `~/.config/.data` (`client.jar` for example is placed there by `lib.jar` [here](https://gist.github.com/SilverAndro/a992f85bec29bb248c354ccf5d2206fe#file-boostrap-java-L169)), and not checking for the registry keys or systemd services also placed by stage 2

i've tested this on both platforms and it seems to be working as expected