### PR TITLE
Adds exit codes for detections/errors and machine-readable CSV output with an option

### DIFF
--- a/src/main/java/me/cortex/jarscanner/Gui.java
+++ b/src/main/java/me/cortex/jarscanner/Gui.java
@@ -83,7 +83,7 @@ public class Gui {
                     };
 
                     Results run = Main.run(4, searchDir, true, logOutput);
-                    Main.outputRunResults(run, logOutput);
+                    Main.outputRunResults(run, logOutput, null);
                     textArea.append("Done scanning!");
                 } catch (Exception ex) {
                     if (ex instanceof InterruptedException || ex instanceof RejectedExecutionException) {

--- a/src/main/java/me/cortex/jarscanner/Main.java
+++ b/src/main/java/me/cortex/jarscanner/Main.java
@@ -33,7 +33,7 @@ public class Main {
      * Main method. Checks arguments and scans the specified directory for malicious code signatures. Outputs the
      * results of the scan to the console.
      *
-     * @param args the command line arguments (number of threads, directory to scan, and whether to emit walk errors)
+     * @param args the command line arguments (number of threads, directory to scan, whether to emit walk errors, and whether to output machine-readable CSV)
      */
     public static void main(String[] args) {
         // Check arguments
@@ -97,7 +97,7 @@ public class Main {
      *
      * @param results   the resulting from {@link #run(int, Path, boolean, Function)}.
      * @param logOutput the function to use for logging human-readable output
-     * @param logCSV the function to use for logging machine-readable CSV output, pass null for no CSV output
+     * @param logCSV    the function to use for logging machine-readable CSV output, pass null for no CSV output
      * 
      */
     public static void outputRunResults(Results results, Function<String, String> logOutput, Function<String, String> logCSV) {

--- a/src/main/java/me/cortex/jarscanner/Main.java
+++ b/src/main/java/me/cortex/jarscanner/Main.java
@@ -45,8 +45,13 @@ public class Main {
         int nThreads = Integer.parseInt(args[0]);
         Path dirToCheck = new File(args[1]).toPath();
         boolean emitWalkErrors = false;
+        boolean machineReadableOutput = false;
         if (args.length > 2) {
             emitWalkErrors = Boolean.parseBoolean(args[2]);
+        }
+
+        if (args.length > 3) {
+            machineReadableOutput = Boolean.parseBoolean(args[3]);
         }
 
         // Create log output function
@@ -106,6 +111,13 @@ public class Main {
                         logOutput.apply(Constants.ANSI_RED + "[" + stage2InfectionNumber + "] " + Constants.ANSI_WHITE + stage2Infection + Constants.ANSI_RESET);
                     }
                 }
+                if(machineReadableOutput)
+                {
+                    //printing to stderr instead so this output can be used by a program while the full human-readable logs go to a file
+                    System.err.println("stage1,stage2");
+                    System.err.println(stage1Detections.size()+","+stage2Detections.size());
+                }
+                System.exit(1); //nonzero exit code to indicate infections found
             }
         }
     }


### PR DESCRIPTION
Basically what the title says, I wrote some small changes to output an exit code of 2 if Fractureiser is detected (1 for actual caught errors), and added an argument that if set to "true", will output CSV logs (of the form `stage number,infected file` to stderr) for all detections (no logs will be output if nothing is detected).

Basically this combines both solutions I mentioned into one and should fix #58, because I'm not sure which you'd prefer.

Edit: reworded the PR to link to the issue properly.